### PR TITLE
Bump @hapi/hoek and @hapi/joi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -822,20 +822,27 @@
       "integrity": "sha512-mV6T0IYqb0xL1UALPFplXYQmR0twnXG0M6jUswpquqT2sD12BOiCiLy3EvMp/Fy7s3DZElC4/aPjEjo2jeZpvw==",
       "dev": true
     },
+    "@hapi/bourne": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
+      "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
+      "dev": true
+    },
     "@hapi/hoek": {
-      "version": "6.2.4",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
-      "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
+      "integrity": "sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==",
       "dev": true
     },
     "@hapi/joi": {
-      "version": "15.0.3",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.0.3.tgz",
-      "integrity": "sha512-z6CesJ2YBwgVCi+ci8SI8zixoj8bGFn/vZb9MBPbSyoxsS2PnWYjHcyTM17VLK6tx64YVK38SDIh10hJypB+ig==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-15.1.1.tgz",
+      "integrity": "sha512-entf8ZMOK8sc+8YfeOlM8pCfg3b5+WZIKBfUaaJT8UsjAAPjartzxIYm3TIbjvA4u+u++KbcXD38k682nVHDAQ==",
       "dev": true,
       "requires": {
         "@hapi/address": "2.x.x",
-        "@hapi/hoek": "6.x.x",
+        "@hapi/bourne": "1.x.x",
+        "@hapi/hoek": "8.x.x",
         "@hapi/topo": "3.x.x"
       }
     },
@@ -846,6 +853,14 @@
       "dev": true,
       "requires": {
         "@hapi/hoek": "6.x.x"
+      },
+      "dependencies": {
+        "@hapi/hoek": {
+          "version": "6.2.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-6.2.4.tgz",
+          "integrity": "sha512-HOJ20Kc93DkDVvjwHyHawPwPkX44sIrbXazAUDiUXaY2R9JwQGo2PhFfnQtdrsIe4igjG2fPgMra7NYw7qhy0A==",
+          "dev": true
+        }
       }
     },
     "@intervolga/optimize-cssnano-plugin": {


### PR DESCRIPTION
Bumps [@hapi/hoek](https://github.com/hapijs/hoek) and [@hapi/joi](https://github.com/hapijs/joi). These dependencies needed to be updated together.

Updates `@hapi/hoek` from 6.2.4 to 8.5.1
- [Release notes](https://github.com/hapijs/hoek/releases)
- [Commits](https://github.com/hapijs/hoek/compare/v6.2.4...v8.5.1)

Updates `@hapi/joi` from 15.0.3 to 15.1.1
- [Release notes](https://github.com/hapijs/joi/releases)
- [Commits](https://github.com/hapijs/joi/compare/v15.0.3...v15.1.1)

---
updated-dependencies:
- dependency-name: "@hapi/hoek" dependency-type: indirect
- dependency-name: "@hapi/joi" dependency-type: indirect ...

Signed-off-by: dependabot[bot] <support@github.com>